### PR TITLE
chore: Add CHANGELOG check in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check CHANGELOG for version (tags only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md does not contain an entry for version $VERSION"
+            echo "Please add a section '## [$VERSION] - YYYY-MM-DD' to CHANGELOG.md before creating a release."
+            exit 1
+          fi
+          echo "CHANGELOG.md contains entry for version $VERSION"
+
       - name: Set release type
         id: release_type
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to SimpleDisenchant will be documented in this file.
 
+## [1.2.1] - 2025-02-10
+
+### Fixed
+- Blacklist is now per-character instead of global (#10)
+- Blacklist now uses unique item identification (item link with bonus IDs) instead of generic itemID (#11)
+  - This allows blacklisting a specific item variant without affecting other items of the same base type
+
+### Changed
+- Changed SavedVariables to SavedVariablesPerCharacter
+- Tooltip in blacklist frame shows exact item stats via SetHyperlink
+
 ## [1.2.0] - 2025-02-09
 
 ### Added


### PR DESCRIPTION
## Summary
- Add CI check to verify CHANGELOG.md contains an entry for the tag version before releasing
- Update CHANGELOG.md with v1.2.1 release notes (was missing)

## How it works
When a tag `vX.Y.Z` is pushed, the workflow will:
1. Check if CHANGELOG.md contains `## [X.Y.Z]`
2. If not found, the workflow fails with a clear error message
3. If found, the release proceeds normally

This prevents releasing without documenting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)