### PR TITLE
fix(interface): bump TOC for WoW 12.0.7

### DIFF
--- a/SimpleDisenchant.toc
+++ b/SimpleDisenchant.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 120001, 120005
+## Interface: 120000, 120001, 120005, 120007
 ## Title: Simple Disenchant
 ## Author: Artenola
 ## Version: 1.7.1 # x-release-please-version


### PR DESCRIPTION
## Summary

- Adds `120007` to the `## Interface` line in `SimpleDisenchant.toc`
- Marks the addon as compatible with WoW **12.0.7**

## Changes

```
## Interface: 120000, 120001, 120005, 120007
```

## Test plan

- [ ] Load addon in WoW 12.0.7 — no "out of date" warning in addon list
- [ ] Disenchant flow works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)