### PR TITLE
chore(ci): remove develop branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,10 +3,11 @@ name: CI/CD
 on:
   push:
     branches:
-      - develop
       - main
       - 'feature/**'
       - 'features/**'
+      - 'fix/**'
+      - 'chore/**'
 
 # Skip runs triggered by release-please bump commits on main.
 # Releases are now handled entirely by release-please.yml.
@@ -43,10 +44,6 @@ jobs:
             SHORT_SHA=$(git rev-parse --short HEAD)
             VERSION="${TOC_VERSION}-beta-${SHORT_SHA}"
             TYPE="beta"
-          elif [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
-            SHORT_SHA=$(git rev-parse --short HEAD)
-            VERSION="${TOC_VERSION}-alpha-${SHORT_SHA}"
-            TYPE="alpha"
           else
             SHORT_SHA=$(git rev-parse --short HEAD)
             VERSION="${TOC_VERSION}-alpha-${SHORT_SHA}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,14 +3,14 @@ name: Lint
 on:
   pull_request:
     branches:
-      - develop
       - main
   push:
     branches:
-      - develop
       - main
       - 'feature/**'
       - 'features/**'
+      - 'fix/**'
+      - 'chore/**'
 
 jobs:
   luacheck:


### PR DESCRIPTION
## Summary

Simplifie le workflow : plus de branche `develop`.

- Les feature/fix/chore branches vont directement vers `main`
- Suppression du build type `alpha` (était lié à `develop`)
- Ajout de `fix/**` et `chore/**` dans les triggers CI/CD et Lint

## Nouveau flow

```
feature/xxx  ──→  PR → main  ──→  release-please PR → tag → release
fix/xxx      ──→  PR → main
chore/xxx    ──→  PR → main
```

## Test plan

- [ ] Lint se déclenche sur PR vers main
- [ ] CI/CD se déclenche en dry-run sur les branches feature/fix/chore
- [ ] CI/CD se déclenche en beta sur main (hors commits release-please)

🤖 Generated with [Claude Code](https://claude.com/claude-code)