### PR TITLE
fix(ci): publication beta auto sur main, alpha manuelle

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,14 +14,17 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build & Publish
     runs-on: ubuntu-latest
     # Skip bump commits from release-please on main
     if: "github.ref != 'refs/heads/main' || !startsWith(github.event.head_commit.message, 'chore: release')"
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: |
@@ -29,9 +32,11 @@ jobs:
           sudo apt-get install -y --no-install-recommends subversion jq zip rsync
 
       # ──────────────────────────────────────────────
-      # Compute version from TOC + ref
+      # Compute version and release type from TOC + ref
+      #   main          → beta  (auto-published)
+      #   other branches → alpha (build only, publish manually via publish.yml)
       # ──────────────────────────────────────────────
-      - name: Compute version
+      - name: Compute version and type
         id: info
         run: |
           TOC_VERSION=$(grep -oP '## Version:\s*\K[^\s#]+' SimpleDisenchant.toc)
@@ -39,16 +44,37 @@ jobs:
 
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             VERSION="${TOC_VERSION}-beta-${SHORT_SHA}"
+            TYPE="beta"
           else
             VERSION="${TOC_VERSION}-alpha-${SHORT_SHA}"
+            TYPE="alpha"
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "→ Version: $VERSION"
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "→ Version: $VERSION ($TYPE)"
 
       - name: Set TOC version
         run: |
           sed -i "s/^## Version: .*/## Version: ${{ steps.info.outputs.version }}/" SimpleDisenchant.toc
+
+      # ──────────────────────────────────────────────
+      # CHANGELOG extraction (for upload metadata)
+      # ──────────────────────────────────────────────
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          VERSION="${{ steps.info.outputs.version }}"
+          BASE_VERSION="${VERSION%%-*}"
+          BODY=""
+          if grep -q "## \[$BASE_VERSION\]" CHANGELOG.md; then
+            BODY=$(sed -n "/^## \[$BASE_VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
+          fi
+          {
+            echo "body<<CHANGELOG_EOF"
+            echo "$BODY"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       # ──────────────────────────────────────────────
       # Build package (zip with externals)
@@ -60,7 +86,7 @@ jobs:
           VERSION: ${{ steps.info.outputs.version }}
 
       # ──────────────────────────────────────────────
-      # Upload artifact for manual publish
+      # Save artifact (so alpha builds can be published manually later)
       # ──────────────────────────────────────────────
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -70,14 +96,35 @@ jobs:
           retention-days: 30
 
       # ──────────────────────────────────────────────
+      # Auto-publish beta to CurseForge & Wago (main only)
+      # alpha builds are NOT published here — use the Publish workflow.
+      # ──────────────────────────────────────────────
+      - name: Upload to CurseForge & Wago
+        if: steps.info.outputs.type == 'beta'
+        run: ./scripts/upload-package.sh
+        env:
+          ARCHIVE: ${{ steps.build.outputs.archive }}
+          VERSION: ${{ steps.info.outputs.version }}
+          RELEASE_TYPE: ${{ steps.info.outputs.type }}
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          CHANGELOG_BODY: ${{ steps.changelog.outputs.body }}
+
+      # ──────────────────────────────────────────────
       # Summary
       # ──────────────────────────────────────────────
       - name: Generate summary
         run: |
           {
-            echo "## ${{ steps.info.outputs.version }}"
+            echo "## ${{ steps.info.outputs.version }} (${{ steps.info.outputs.type }})"
             echo ""
             echo "**Archive:** \`${{ steps.build.outputs.archive_name }}\`"
             echo ""
-            echo "> ℹ️ Pour publier sur CurseForge/Wago, utilise le workflow **Publish** manuellement."
+            if [[ "${{ steps.info.outputs.type }}" == "beta" ]]; then
+              echo "> ✅ Publié automatiquement en beta sur CurseForge & Wago."
+            else
+              echo "> ℹ️ Build alpha. Pour publier, lance le workflow **Publish** manuellement."
+            fi
+            echo ""
+            echo "${{ steps.changelog.outputs.body }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,13 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Branch or commit to publish (ex: main, fix/mon-bug)'
+        description: 'Branch or commit to publish (ex: fix/mon-bug)'
         required: true
-        default: 'main'
+        default: ''
       release_type:
         description: 'Release type'
         required: true
-        default: 'beta'
+        default: 'alpha'
         type: choice
         options:
           - alpha


### PR DESCRIPTION
## Summary

Corrige le pipeline pour coller à la cible :

| Déclencheur | Build | Publication CF/Wago |
|-------------|-------|---------------------|
| Push `main` | beta | ✅ **auto** |
| Push `feature/**`, `fix/**`, `chore/**` | alpha | ❌ (manuel via Publish) |
| release-please | release | ✅ auto (stable) |

## Détails

- **`ci-cd.yml`** : `main` rebuild + upload beta automatiquement. Les autres branches buildent une alpha (artifact 30 jours) sans publier.
- **`publish.yml`** : workflow manuel, défaut `alpha`, pour publier une branche à la demande.
- **`release-please.yml`** : inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)