### PR TITLE
fix(interface): update interface version for WoW 12.1.0

### DIFF
--- a/SimpleDisenchant.toc
+++ b/SimpleDisenchant.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 120001, 120005, 120007
+## Interface: 120007, 120100
 ## Title: Simple Disenchant
 ## Author: Artenola
 ## Version: 1.7.3 # x-release-please-version


### PR DESCRIPTION
## Summary

Updates the `## Interface` line in the TOC for the **WoW 12.1.0** release.

## Changes

- `SimpleDisenchant.toc`: add `120100` (12.1.0) to the Interface line

## Context

No code changes required: the [12.1.0 API review](https://warcraft.wiki.gg/wiki/Patch_12.1.0/API_changes) doesn't affect any of the APIs used by the addon (container, item, equipment sets, secure buttons, tooltip, scrollbox). The patch centers on auras and the security model, outside our scope.

This bump only serves to clear the "out of date" flag in the addon list.